### PR TITLE
notebook to track github metrics

### DIFF
--- a/notebooks/thoth_support_github_data.ipynb
+++ b/notebooks/thoth_support_github_data.ipynb
@@ -1,0 +1,860 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "50dcee0c-1ec3-4f00-9fe0-f34759445efe",
+   "metadata": {},
+   "source": [
+    "# GitHub Repository (`thoth-station/support`) Metric Analysis\n",
+    "\n",
+    "In this notebook, we will fetch the GitHub Issue/PR data for the `support` repositories mentioned in [thoth-station](https://github.com/thoth-station/support) organization using the [MI tool](https://github.com/thoth-station/mi), pre-process the raw data into suitable data frames and store them as parquet files to an s3 bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d2c5a94e-ee0e-4be8-b4a6-4756a48abc27",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import yaml\n",
+    "import requests\n",
+    "from dotenv import find_dotenv, load_dotenv\n",
+    "import warnings\n",
+    "import trino\n",
+    "from s3_communication import S3Communication\n",
+    "from github import Github\n",
+    "import pandas as pd\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "load_dotenv(find_dotenv())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "10840dbf-4591-4b5b-bab6-b517f7eb3ffd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Create a .env file on your local with the correct configs\n",
+    "GITHUB_ACCESS_TOKEN = os.getenv(\"GITHUB_ACCESS_TOKEN\")\n",
+    "\n",
+    "s3_bucket = os.getenv(\"S3_BUCKET\")\n",
+    "s3_endpoint_url = os.getenv(\"S3_ENDPOINT\")\n",
+    "aws_access_key_id = os.getenv(\"S3_ACCESS_KEY\")\n",
+    "aws_secret_access_key = os.getenv(\"S3_SECRET_KEY\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "479ac8ce-ee25-4266-91c7-09e5b018bac9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note: The GitHub access token needs to be exported before importing the srcopmetrics package (current bug)\n",
+    "from srcopsmetrics.entities.issue import Issue\n",
+    "from srcopsmetrics.entities.pull_request import PullRequest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f85e435f-ac52-46a7-bc89-911d44c59d97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# init s3 connector\n",
+    "s3c = S3Communication(\n",
+    "    s3_endpoint_url, aws_access_key_id, aws_secret_access_key, s3_bucket\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9ef55b30-7515-4617-9c95-3ae91b41237b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# repo from where the data is extracted\n",
+    "org_repo = [\"thoth-station/support\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "25cb4a68-37b5-4ba5-b99c-7d2d68791464",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "******----->>Extracting data from thoth-station/support\n",
+      "INFO:srcopsmetrics.github_knowledge:Overall repositories found: 1\n",
+      "INFO:srcopsmetrics.bot_knowledge:######################## Analysing thoth-station/support ########################\n",
+      "\n",
+      "INFO:srcopsmetrics.utils:No repo identified, creating new directory at /opt/app-root/src/metrics/notebooks/srcopsmetrics/bot_knowledge/thoth-station/support\n",
+      "INFO:srcopsmetrics.bot_knowledge:########################\n",
+      "INFO:srcopsmetrics.bot_knowledge:Detected entities:\n",
+      "CodeFrequency # Commit # DependencyUpdate # Fork # Issue # IssueEvent # KebechetUpdateManager # License # PullRequest # PullRequestDiscussion # RawIssue # RawPullRequest # ReadMe # Release # Stargazer # ThothAdviseMetrics # ThothMetrics # ThothMetrics # ThothMetrics # ThothVersionManagerMetrics # TrafficClones # TrafficPaths # TrafficPaths # TrafficReferrers # TrafficClones # TrafficViews\n",
+      "INFO:srcopsmetrics.bot_knowledge:########################\n",
+      "INFO:srcopsmetrics.bot_knowledge:Issue inspection\n",
+      "INFO:srcopsmetrics.entities.tools.storage:Loading knowledge locally\n",
+      "INFO:srcopsmetrics.entities.tools.storage:Knowledge /opt/app-root/src/metrics/notebooks/srcopsmetrics/bot_knowledge/thoth-station/support/Issue.json not found locally\n",
+      "INFO:srcopsmetrics.entities.interface:No previous knowledge of type Issue found\n",
+      "INFO:srcopsmetrics.iterator:-------------Issue Analysis-------------\n",
+      "100%|████████████████████| 220/220 [01:50<00:00,  2.00it/s, RATE remaining=4246]\n",
+      "INFO:srcopsmetrics.entities.interface:Knowledge file Issue.json\n",
+      "INFO:srcopsmetrics.entities.interface:new 212 entities\n",
+      "INFO:srcopsmetrics.entities.interface:(overall 212 entities)\n",
+      "INFO:srcopsmetrics.entities.interface:Saved locally at /opt/app-root/src/metrics/notebooks/srcopsmetrics/bot_knowledge/thoth-station/support/Issue.json\n",
+      "INFO:srcopsmetrics.bot_knowledge:\n",
+      "\n",
+      "INFO:srcopsmetrics.bot_knowledge:PullRequest inspection\n",
+      "INFO:srcopsmetrics.entities.tools.storage:Loading knowledge locally\n",
+      "INFO:srcopsmetrics.entities.tools.storage:Knowledge /opt/app-root/src/metrics/notebooks/srcopsmetrics/bot_knowledge/thoth-station/support/PullRequest.json not found locally\n",
+      "INFO:srcopsmetrics.entities.interface:No previous knowledge of type PullRequest found\n",
+      "INFO:srcopsmetrics.iterator:-------------PullRequest Analysis-------------\n",
+      "INFO:srcopsmetrics.entities.pull_request:Extracting PR #195                     \n",
+      "INFO:srcopsmetrics.entities.pull_request:Extracting PR #146                     \n",
+      "INFO:srcopsmetrics.entities.pull_request:Extracting PR #116                     \n",
+      "INFO:srcopsmetrics.entities.pull_request:      -analysing review no. 1/1        \n",
+      "INFO:srcopsmetrics.entities.pull_request:Extracting PR #115                     \n",
+      "INFO:srcopsmetrics.entities.pull_request:      -analysing review no. 1/1        \n",
+      "INFO:srcopsmetrics.entities.pull_request:Extracting PR #99                      \n",
+      "INFO:srcopsmetrics.entities.pull_request:      -analysing review no. 1/2        \n",
+      "INFO:srcopsmetrics.entities.pull_request:      -analysing review no. 2/2        \n",
+      "INFO:srcopsmetrics.entities.pull_request:Extracting PR #98                      \n",
+      "INFO:srcopsmetrics.entities.pull_request:      -analysing review no. 1/4        \n",
+      "INFO:srcopsmetrics.entities.pull_request:      -analysing review no. 2/4        \n",
+      "INFO:srcopsmetrics.entities.pull_request:      -analysing review no. 3/4        \n",
+      "INFO:srcopsmetrics.entities.pull_request:      -analysing review no. 4/4        \n",
+      "INFO:srcopsmetrics.entities.pull_request:Extracting PR #97                      \n",
+      "INFO:srcopsmetrics.entities.pull_request:Extracting PR #21                      \n",
+      "INFO:srcopsmetrics.entities.pull_request:      -analysing review no. 1/1        \n",
+      "100%|████████████████████████| 8/8 [00:10<00:00,  1.29s/it, RATE remaining=4178]\n",
+      "INFO:srcopsmetrics.entities.interface:Knowledge file PullRequest.json\n",
+      "INFO:srcopsmetrics.entities.interface:new 8 entities\n",
+      "INFO:srcopsmetrics.entities.interface:(overall 8 entities)\n",
+      "INFO:srcopsmetrics.entities.interface:Saved locally at /opt/app-root/src/metrics/notebooks/srcopsmetrics/bot_knowledge/thoth-station/support/PullRequest.json\n",
+      "INFO:srcopsmetrics.bot_knowledge:\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Remove any existing old data\n",
+    "!rm -r srcopsmetrics/\n",
+    "\n",
+    "\n",
+    "for repo in org_repo:\n",
+    "    org = repo.split('/')[0]\n",
+    "    repo = repo.split('/')[1]\n",
+    "    print(f\"******----->>Extracting data from {org}/{repo}\")\n",
+    "    !python -m srcopsmetrics.cli -clr $org/$repo -e Issue,PullRequest # noqa: E999"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc2542f1-be2a-46ee-8448-005eb826ba44",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Issue\n",
+    "\n",
+    "Now, lets fetch the issues for the repository and save it as a dataframe in a S3 bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "66fdab7c-8983-4499-8f2f-ac031aee562a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_issue_metrics(org, repo):\n",
+    "    # read repo data we fetched in previous step via MI\n",
+    "    issue = Issue(f\"{org}/{repo}\")\n",
+    "    issue_df = issue.load_previous_knowledge(is_local=True)\n",
+    "    issue_df = issue_df.reset_index()\n",
+    "\n",
+    "    # Retain only relevant columns\n",
+    "    issue_cols_to_drop = [\"labels\", \"interactions\"]\n",
+    "    issue_df = issue_df.drop(columns=issue_cols_to_drop)\n",
+    "\n",
+    "    # add sig, org, repo columns\n",
+    "    issue_df[\"org\"] = org\n",
+    "    issue_df[\"repo\"] = repo\n",
+    "\n",
+    "    return issue_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "67293889-0806-4823-ae0b-ede4c79cdf70",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>title</th>\n",
+       "      <th>body</th>\n",
+       "      <th>created_by</th>\n",
+       "      <th>created_at</th>\n",
+       "      <th>closed_by</th>\n",
+       "      <th>closed_at</th>\n",
+       "      <th>org</th>\n",
+       "      <th>repo</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>223</td>\n",
+       "      <td>Kebechet update manager: GitCommandError on ke...</td>\n",
+       "      <td>## Description\\nThis is an automated issue gen...</td>\n",
+       "      <td>khebhut[bot]</td>\n",
+       "      <td>2022-06-01 12:49:54</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>thoth-station</td>\n",
+       "      <td>support</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>222</td>\n",
+       "      <td>Kebechet version manager: GithubAPIException o...</td>\n",
+       "      <td>## Description\\nThis is an automated issue gen...</td>\n",
+       "      <td>khebhut[bot]</td>\n",
+       "      <td>2022-06-01 05:46:15</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>thoth-station</td>\n",
+       "      <td>support</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>221</td>\n",
+       "      <td>Kebechet update manager: InternalError on kebe...</td>\n",
+       "      <td>## Description\\nThis is an automated issue gen...</td>\n",
+       "      <td>khebhut[bot]</td>\n",
+       "      <td>2022-05-24 12:50:03</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>thoth-station</td>\n",
+       "      <td>support</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>220</td>\n",
+       "      <td>Include package osc-ingest-tools in recommenda...</td>\n",
+       "      <td>### Package name\\n\\nosc-ingest-tools\\n\\n### Py...</td>\n",
+       "      <td>fridex</td>\n",
+       "      <td>2022-05-23 13:58:23</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>thoth-station</td>\n",
+       "      <td>support</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>219</td>\n",
+       "      <td>the URL that points to an advise's results giv...</td>\n",
+       "      <td>**Describe the bug**\\r\\n\\r\\nWhen I ask for an ...</td>\n",
+       "      <td>codificat</td>\n",
+       "      <td>2022-05-20 16:06:03</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>thoth-station</td>\n",
+       "      <td>support</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    id                                              title  \\\n",
+       "0  223  Kebechet update manager: GitCommandError on ke...   \n",
+       "1  222  Kebechet version manager: GithubAPIException o...   \n",
+       "2  221  Kebechet update manager: InternalError on kebe...   \n",
+       "3  220  Include package osc-ingest-tools in recommenda...   \n",
+       "4  219  the URL that points to an advise's results giv...   \n",
+       "\n",
+       "                                                body    created_by  \\\n",
+       "0  ## Description\\nThis is an automated issue gen...  khebhut[bot]   \n",
+       "1  ## Description\\nThis is an automated issue gen...  khebhut[bot]   \n",
+       "2  ## Description\\nThis is an automated issue gen...  khebhut[bot]   \n",
+       "3  ### Package name\\n\\nosc-ingest-tools\\n\\n### Py...        fridex   \n",
+       "4  **Describe the bug**\\r\\n\\r\\nWhen I ask for an ...     codificat   \n",
+       "\n",
+       "           created_at closed_by closed_at            org     repo  \n",
+       "0 2022-06-01 12:49:54      None       NaT  thoth-station  support  \n",
+       "1 2022-06-01 05:46:15      None       NaT  thoth-station  support  \n",
+       "2 2022-05-24 12:50:03      None       NaT  thoth-station  support  \n",
+       "3 2022-05-23 13:58:23      None       NaT  thoth-station  support  \n",
+       "4 2022-05-20 16:06:03      None       NaT  thoth-station  support  "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# lets read a sample df\n",
+    "issue_df = get_issue_metrics(org=\"thoth-station\", repo=\"support\")\n",
+    "issue_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "bd536b2f-a47d-4ec7-af84-60401245861c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'ResponseMetadata': {'RequestId': 'tx00000000000000007263c-0062991e46-2f12b8-ocs-storagecluster-cephobjectstore',\n",
+       "  'HostId': '',\n",
+       "  'HTTPStatusCode': 200,\n",
+       "  'HTTPHeaders': {'content-length': '0',\n",
+       "   'etag': '\"6d80922111b0ab9fcfb5144d036857ca\"',\n",
+       "   'accept-ranges': 'bytes',\n",
+       "   'x-amz-request-id': 'tx00000000000000007263c-0062991e46-2f12b8-ocs-storagecluster-cephobjectstore',\n",
+       "   'date': 'Thu, 02 Jun 2022 20:32:06 GMT',\n",
+       "   'set-cookie': 'bbdcd938787a45e68f8d240a4e2dadcf=8a437562f974804482699da2db9fb9f7; path=/; HttpOnly'},\n",
+       "  'RetryAttempts': 0},\n",
+       " 'ETag': '\"6d80922111b0ab9fcfb5144d036857ca\"'}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# read in and process issue dfs for all repos\n",
+    "# then upload the processed df to s3 as a parquet file\n",
+    "\n",
+    "\n",
+    "# upload to bucket\n",
+    "s3c.upload_df_to_s3(\n",
+    "    df=issue_df,\n",
+    "    s3_prefix=f\"open-services-group/metrics/{org}-{repo}-github/issues\",\n",
+    "    s3_key=f\"{org}-{repo}-issues.parquet\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f7ec752-c048-4bbf-b92f-f0ab2445520d",
+   "metadata": {},
+   "source": [
+    "## Pull-Request\n",
+    "\n",
+    "Now, lets fetch the PRs for the repository and save it as a dataframe in a S3 bucket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "878eb71c-8431-4942-bc54-d4b73b839e4d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_pr_metrics(org, repo):\n",
+    "    # read repo data we fetched in previous step via MI\n",
+    "    pr = PullRequest(f\"{org}/{repo}\")\n",
+    "    pr_df = pr.load_previous_knowledge(is_local=True)\n",
+    "    pr_df = pr_df.reset_index()\n",
+    "\n",
+    "    # Retain only relevant columns\n",
+    "    pr_cols_to_drop = [\"interactions\", \"reviews\", \"labels\", \"commits\", \"changed_files\"]\n",
+    "    prs_df = pr_df.drop(columns=pr_cols_to_drop)\n",
+    "\n",
+    "    # add sigs,org,repo\n",
+    "    prs_df[\"org\"] = org\n",
+    "    prs_df[\"repo\"] = repo\n",
+    "\n",
+    "    return prs_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "fabaf77f-d221-4201-9956-5c95b8171ea5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>title</th>\n",
+       "      <th>body</th>\n",
+       "      <th>size</th>\n",
+       "      <th>created_by</th>\n",
+       "      <th>created_at</th>\n",
+       "      <th>closed_at</th>\n",
+       "      <th>closed_by</th>\n",
+       "      <th>merged_at</th>\n",
+       "      <th>merged_by</th>\n",
+       "      <th>commits_number</th>\n",
+       "      <th>changed_files_number</th>\n",
+       "      <th>first_review_at</th>\n",
+       "      <th>first_approve_at</th>\n",
+       "      <th>org</th>\n",
+       "      <th>repo</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>195</td>\n",
+       "      <td>Thoth Configuration Initialization</td>\n",
+       "      <td>## Automatic configuration initialization\\nThe...</td>\n",
+       "      <td>M</td>\n",
+       "      <td>khebhut[bot]</td>\n",
+       "      <td>2022-03-02 07:53:44</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>None</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>None</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>thoth-station</td>\n",
+       "      <td>support</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>146</td>\n",
+       "      <td>Thoth Configuration Initialization</td>\n",
+       "      <td>## Automatic configuration initialization\\nThe...</td>\n",
+       "      <td>M</td>\n",
+       "      <td>khebhut[bot]</td>\n",
+       "      <td>2021-11-18 14:17:40</td>\n",
+       "      <td>2022-02-17 09:32:16</td>\n",
+       "      <td>sesheta</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>None</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>thoth-station</td>\n",
+       "      <td>support</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>116</td>\n",
+       "      <td>Add optional Python package index URL to the p...</td>\n",
+       "      <td>Let's have also this field as per discussion w...</td>\n",
+       "      <td>XS</td>\n",
+       "      <td>fridex</td>\n",
+       "      <td>2021-10-18 11:11:44</td>\n",
+       "      <td>2021-10-18 11:24:04</td>\n",
+       "      <td>fridex</td>\n",
+       "      <td>2021-10-18 11:24:04</td>\n",
+       "      <td>fridex</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2021-10-18 11:15:15</td>\n",
+       "      <td>2021-10-18 11:15:15</td>\n",
+       "      <td>thoth-station</td>\n",
+       "      <td>support</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>115</td>\n",
+       "      <td>Template for registering a Python package index</td>\n",
+       "      <td>See https://github.com/thoth-station/support/p...</td>\n",
+       "      <td>M</td>\n",
+       "      <td>fridex</td>\n",
+       "      <td>2021-10-18 11:02:32</td>\n",
+       "      <td>2021-10-18 11:24:32</td>\n",
+       "      <td>fridex</td>\n",
+       "      <td>2021-10-18 11:24:32</td>\n",
+       "      <td>fridex</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2021-10-18 11:14:45</td>\n",
+       "      <td>2021-10-18 11:14:45</td>\n",
+       "      <td>thoth-station</td>\n",
+       "      <td>support</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>99</td>\n",
+       "      <td>Add template for requesting a package in Thoth...</td>\n",
+       "      <td>None</td>\n",
+       "      <td>M</td>\n",
+       "      <td>fridex</td>\n",
+       "      <td>2021-10-11 19:42:39</td>\n",
+       "      <td>2021-10-18 10:53:53</td>\n",
+       "      <td>fridex</td>\n",
+       "      <td>2021-10-18 10:53:53</td>\n",
+       "      <td>fridex</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2021-10-18 10:45:16</td>\n",
+       "      <td>2021-10-18 10:52:07</td>\n",
+       "      <td>thoth-station</td>\n",
+       "      <td>support</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    id                                              title  \\\n",
+       "0  195                 Thoth Configuration Initialization   \n",
+       "1  146                 Thoth Configuration Initialization   \n",
+       "2  116  Add optional Python package index URL to the p...   \n",
+       "3  115    Template for registering a Python package index   \n",
+       "4   99  Add template for requesting a package in Thoth...   \n",
+       "\n",
+       "                                                body size    created_by  \\\n",
+       "0  ## Automatic configuration initialization\\nThe...    M  khebhut[bot]   \n",
+       "1  ## Automatic configuration initialization\\nThe...    M  khebhut[bot]   \n",
+       "2  Let's have also this field as per discussion w...   XS        fridex   \n",
+       "3  See https://github.com/thoth-station/support/p...    M        fridex   \n",
+       "4                                               None    M        fridex   \n",
+       "\n",
+       "           created_at           closed_at closed_by           merged_at  \\\n",
+       "0 2022-03-02 07:53:44                 NaT      None                 NaT   \n",
+       "1 2021-11-18 14:17:40 2022-02-17 09:32:16   sesheta                 NaT   \n",
+       "2 2021-10-18 11:11:44 2021-10-18 11:24:04    fridex 2021-10-18 11:24:04   \n",
+       "3 2021-10-18 11:02:32 2021-10-18 11:24:32    fridex 2021-10-18 11:24:32   \n",
+       "4 2021-10-11 19:42:39 2021-10-18 10:53:53    fridex 2021-10-18 10:53:53   \n",
+       "\n",
+       "  merged_by  commits_number  changed_files_number     first_review_at  \\\n",
+       "0      None               1                     1                 NaT   \n",
+       "1      None               1                     1                 NaT   \n",
+       "2    fridex               1                     1 2021-10-18 11:15:15   \n",
+       "3    fridex               1                     1 2021-10-18 11:14:45   \n",
+       "4    fridex               1                     1 2021-10-18 10:45:16   \n",
+       "\n",
+       "     first_approve_at            org     repo  \n",
+       "0                 NaT  thoth-station  support  \n",
+       "1                 NaT  thoth-station  support  \n",
+       "2 2021-10-18 11:15:15  thoth-station  support  \n",
+       "3 2021-10-18 11:14:45  thoth-station  support  \n",
+       "4 2021-10-18 10:52:07  thoth-station  support  "
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pr_df = get_pr_metrics(org=\"thoth-station\", repo=\"support\")\n",
+    "pr_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "a01c05e1-c0be-4268-8361-803f9e7b4e5e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'ResponseMetadata': {'RequestId': 'tx00000000000000007263d-0062991e48-2f12b8-ocs-storagecluster-cephobjectstore',\n",
+       "  'HostId': '',\n",
+       "  'HTTPStatusCode': 200,\n",
+       "  'HTTPHeaders': {'content-length': '0',\n",
+       "   'etag': '\"ec919117d21d9345f53053fd2ffc7a30\"',\n",
+       "   'accept-ranges': 'bytes',\n",
+       "   'x-amz-request-id': 'tx00000000000000007263d-0062991e48-2f12b8-ocs-storagecluster-cephobjectstore',\n",
+       "   'date': 'Thu, 02 Jun 2022 20:32:08 GMT',\n",
+       "   'set-cookie': 'bbdcd938787a45e68f8d240a4e2dadcf=8a437562f974804482699da2db9fb9f7; path=/; HttpOnly'},\n",
+       "  'RetryAttempts': 2},\n",
+       " 'ETag': '\"ec919117d21d9345f53053fd2ffc7a30\"'}"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# read in and process pr dfs for all repos\n",
+    "# then upload the processed df to s3 as a parquet file\n",
+    "\n",
+    "# upload to bucket\n",
+    "\n",
+    "s3c.upload_df_to_s3(\n",
+    "    df=pr_df,\n",
+    "    s3_prefix=\"open-services-group/metrics/{org}-{repo}-github/prs\",\n",
+    "    s3_key=f\"{org}-{repo}-prs.parquet\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59311d4f-cb9a-4f80-a7af-c4fb98b85bec",
+   "metadata": {},
+   "source": [
+    "# Create Trino Tables"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6334a4a4-1168-4088-89be-745447989e41",
+   "metadata": {},
+   "source": [
+    "Now that we have the processed data frames stored as parquet files in s3, we can generate [Trino](https://trino.io/) tables from it so that interactive dashboards can be implemented in [Superset](https://superset.apache.org/). We will be connecting to the [Operate First Trino](https://trino.operate-first.cloud/)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "8e853f70-9e7b-47c4-99d7-3b835f36b3e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Map the datatype columns of df to suitable datatype supported in Trino/Superset\n",
+    "_p2smap = {\n",
+    "    \"object\": \"varchar\",\n",
+    "    \"int64\": \"bigint\",\n",
+    "    \"float64\": \"double\",\n",
+    "    \"datetime64[ns]\": \"timestamp\",\n",
+    "    \"bool\": \"boolean\",\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def pandas_type_to_sql(pt):\n",
+    "    st = _p2smap.get(pt)\n",
+    "    if st is not None:\n",
+    "        return st\n",
+    "    raise ValueError(\"unexpected pandas column type '{pt}'\".format(pt=pt))\n",
+    "\n",
+    "\n",
+    "# Generate the Trino table schema\n",
+    "def generate_table_schema_pairs(df):\n",
+    "    ptypes = [str(e) for e in df.dtypes.to_list()]\n",
+    "    stypes = [pandas_type_to_sql(e) for e in ptypes]\n",
+    "    pz = list(zip(df.columns.to_list(), stypes))\n",
+    "    return \",\\n\".join([\"    {n} {t}\".format(n=e[0], t=e[1]) for e in pz])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "301505f5-3849-4bca-9c16-03e7fb873bcc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a Trino client\n",
+    "conn = trino.dbapi.connect(\n",
+    "    auth=trino.auth.BasicAuthentication(\n",
+    "        os.environ[\"TRINO_USER\"], os.environ[\"TRINO_PASSWD\"]\n",
+    "    ),\n",
+    "    host=os.environ[\"TRINO_HOST\"],\n",
+    "    port=int(os.environ[\"TRINO_PORT\"]),\n",
+    "    http_scheme=\"https\",\n",
+    "    verify=True,\n",
+    ")\n",
+    "cur = conn.cursor()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "8b0c9e14-8f32-4913-9d6c-6a9ecdb19233",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['data_science_general_morty']"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Check if Trino connection was successful\n",
+    "cur.execute(\"show catalogs\")\n",
+    "cur.fetchall()[2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "7cf69edf-6b0e-48b4-bea1-c38d4752b842",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_table_from_df(df, table_name, s3_prefix):\n",
+    "    # Create the table with data populated from parquet file\n",
+    "    schema = generate_table_schema_pairs(df)\n",
+    "\n",
+    "    tabledef = \"\"\"CREATE TABLE IF NOT EXISTS data_science_general_morty.default.{table_name}(\n",
+    "    {schema}\n",
+    "    ) with (\n",
+    "        format = 'parquet',\n",
+    "        external_location = 's3a://{s3_bucket}/{s3_prefix}'\n",
+    "    )\"\"\".format(\n",
+    "        table_name=table_name,\n",
+    "        schema=schema,\n",
+    "        s3_prefix=s3_prefix,\n",
+    "        s3_bucket=os.environ[\"S3_BUCKET\"],\n",
+    "    )\n",
+    "\n",
+    "    cur.execute(tabledef)\n",
+    "    return cur.fetchall()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "e3d997bf-49c0-430a-8f16-7cc4c51f01a1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[[True]]"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "create_table_from_df(\n",
+    "    issue_df,\n",
+    "    table_name=\"thoth_support_issues\",\n",
+    "    s3_prefix=\"open-services-group/metrics/thoth-station-support-github/issues\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "d30d1276-c068-4f91-aae8-afa4b81be047",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[[True]]"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "create_table_from_df(\n",
+    "    pr_df,\n",
+    "    table_name=\"thoth_support_prs\",\n",
+    "    s3_prefix=\"open-services-group/metrics/thoth-station-support-github/prs\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9335f53-9755-48b9-a33c-d0d662739755",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "In this notebook we:\n",
+    "\n",
+    "- Fetched GitHub Issue/PR data for a specified org/repo using the MI srcopsmetrics module.\n",
+    "- Pre-processed the raw data into data frames with relevant columns.\n",
+    "- Uploaded the processed data frames as parquet files to an S3 bucket.\n",
+    "- Created suitable tables for the parquet files generated in Trino.\n",
+    "\n",
+    "We can now further explore the GitHub data and create interactive visualization dashboards in Superset."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds a notebook which tracks github metrics from thoth-station/support repo and save them in S3 bucket.

Related:  https://github.com/open-services-group/community/issues/209