### PR TITLE
Update quay push secret for aicoe-ci

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -10,4 +10,4 @@ build:
   registry: quay.io
   registry-org: open-services-group
   registry-project: metrics
-  registry-secret: aicoe-pusher-secret
+  registry-secret: osg-pusher-secret


### PR DESCRIPTION
SSIA

The current secret corresponds to aicoe org, not the open-services-group org. This PR updates that.